### PR TITLE
fix: Manifest file parsing

### DIFF
--- a/src/pcf/manifest.rs
+++ b/src/pcf/manifest.rs
@@ -52,8 +52,17 @@ fn read_xml_file(path: &path::PathBuf) -> Option<(String, usize, usize)> {
     match std::fs::read_to_string(&path) {
         Ok(content) => {
             let mut line_num: usize = 0;
+            let mut control_open = false;
             for line in content.lines() {
                 if line.to_lowercase().contains("<control") {
+                    control_open = true;
+                }
+
+                if line.to_lowercase().contains(">") && control_open {
+                    break;
+                }
+
+                if control_open {
                     if let Some(idx_start) = line.to_lowercase().find("version=") {
                         let substr = &line[idx_start + 8..];
                         let mut char_vec: Vec<char> = Vec::new();


### PR DESCRIPTION
Fixed an issue, where the xml attributes would not be recognised when on seperate lines